### PR TITLE
Prevents occasional error on phone numbers

### DIFF
--- a/lib/google-search/item/local.rb
+++ b/lib/google-search/item/local.rb
@@ -97,7 +97,7 @@ module Google
           @long = hash['lng'].to_f
           @lat = hash['lat'].to_f
           @viewport_mode = hash['viewportmode']
-          @phone_numbers = hash['phoneNumbers'].map { |phone| phone['number'] }
+          @phone_numbers = hash['phoneNumbers'] != nil ? hash['phoneNumbers'].map { |phone| phone['number'] } : []
           @street_address = hash['streetAddress']
           @address_lines = hash['addressLines']
         end


### PR DESCRIPTION
Occasionally, hash['phoneNumbers'] would return nil, thus crashing the app.
