### PR TITLE
Added support for filtering Image search by rights

### DIFF
--- a/lib/google-search/search/image.rb
+++ b/lib/google-search/search/image.rb
@@ -2,21 +2,35 @@
 module Google
   class Search
     class Image < self
-      
+
       #--
       # Mixins
       #++
-      
+
       include SafetyLevel
-      
+
       #--
       # Constants
       #++
-      
+
       SIZES = :icon, :small, :medium, :large, :xlarge, :xxlarge, :huge
       TYPES = :face, :photo, :clipart, :lineart
       EXTENSIONS = :jpg, :png, :gif, :bmp
-      
+      RIGHTS = :cc_publicdomain, :cc_attribute, :cc_sharealike, :cc_noncommercial , :cc_nonderived
+
+
+      ##
+      # Right:
+      #
+      #  - :cc_publicdomain
+      #  - :cc_attribute
+      #  - :cc_sharealike
+      #  - :cc_noncommercial
+      #  - :cc_nonderived
+      #
+
+      attr_accessor :right
+
       ##
       # Image size:
       #
@@ -28,9 +42,9 @@ module Google
       #  - :xxlarge
       #  - :huge
       #
-      
+
       attr_accessor :image_size
-      
+
       ##
       # Image type:
       #
@@ -39,9 +53,9 @@ module Google
       #  - :clipart
       #  - :lineart
       #
-      
+
       attr_accessor :image_type
-      
+
       ##
       # File type:
       #
@@ -50,43 +64,46 @@ module Google
       #  - :png
       #  - :bmp
       #
-      
+
       attr_accessor :file_type
-      
+
       ##
       # Image color.
-      
+
       attr_accessor :color
-      
+
       ##
       # Specific uri to fetch images from.
-      
+
       attr_accessor :uri
-      
+
       #:nodoc:
-      
+
       def initialize options = {}, &block
         @color = options.delete :color
         @image_size = options.delete :image_size
         @image_type = options.delete :image_type
         @file_type = options.delete :file_type
+        @right = options.delete :right
         super
       end
-      
+
       #:nodoc:
-      
+
       def get_uri_params
         validate(:image_size) { |size| size.nil? || size.is_a?(Array) || SIZES.include?(size) }
         validate(:image_type) { |type| type.nil? || TYPES.include?(type) }
         validate(:file_type) { |ext| ext.nil? || EXTENSIONS.include?(ext) }
+        validate(:right) { |rght| rght.nil? || RIGHTS.include?(rght) }
         super + [
           [:safe, safety_level],
           [:imgsz, image_size.is_a?(Array) ? image_size.join('|') : image_size],
           [:imgcolor, color],
           [:imgtype, image_type],
           [:as_filetype, file_type],
+          [:as_rights, right],
           [:as_sitesearch, uri]
-          ]
+        ]
       end
     end
   end

--- a/spec/search_image_spec.rb
+++ b/spec/search_image_spec.rb
@@ -3,9 +3,9 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe Google::Search::Image do
   before :each do
-    @search = Google::Search::Image.new :query => 'foo'  
+    @search = Google::Search::Image.new :query => 'foo'
   end
-  
+
   describe "#get_uri" do
     describe "safety_level" do
       it "should validate" do
@@ -14,7 +14,7 @@ describe Google::Search::Image do
         @search.safety_level = :foo
         lambda { @search.get_uri }.should raise_error(Google::Search::Error, /safety_level/)
       end
-      
+
       it "should provide alternative naming :none, :medium, :high" do
         @search.safety_level = :none
         @search.get_uri.should include('safe=off')
@@ -24,7 +24,16 @@ describe Google::Search::Image do
         @search.get_uri.should include('safe=active')
       end
     end
-    
+
+    describe "right" do
+      it "should validate" do
+        @search.right = :cc_publicdomain
+        @search.get_uri.should include('as_rights=cc_publicdomain')
+        @search.right = :foo
+        lambda { @search.get_uri }.should raise_error(Google::Search::Error, /right/)
+      end
+    end
+
     describe "image_size" do
       it "should validate" do
         @search.image_size = :icon
@@ -35,14 +44,14 @@ describe Google::Search::Image do
         lambda { @search.get_uri }.should raise_error(Google::Search::Error, /image_size/)
       end
     end
-    
+
     describe "color" do
       it "should validate" do
         @search.color = 'blue'
         @search.get_uri.should include('imgcolor=blue')
       end
     end
-    
+
     describe "image_type" do
       it "should validate" do
         @search.image_type = :lineart
@@ -51,7 +60,7 @@ describe Google::Search::Image do
         lambda { @search.get_uri }.should raise_error(Google::Search::Error, /image_type/)
       end
     end
-    
+
     describe "file_type" do
       it "should validate" do
         @search.file_type = :jpg
@@ -60,7 +69,7 @@ describe Google::Search::Image do
         lambda { @search.get_uri }.should raise_error(Google::Search::Error, /file_type/)
       end
     end
-    
+
     describe "uri" do
       it "should validate" do
         @search.uri = 'http://foo.com'


### PR DESCRIPTION
Optionally add parameters to the Image Search queries to filter for public_domain and other CC restrictions.

I based my work off the current deployed RubyGem version tagged `1.0.3` but `master` is at version 1.0.2. Not sure how to do a PR for a tag. 
